### PR TITLE
Update Resend OTP URL

### DIFF
--- a/src/Requests/URLs.php
+++ b/src/Requests/URLs.php
@@ -20,7 +20,7 @@ class URLs
      * URL for Resend OTP Request
      * @var string
      */
-    const OTP_RESEND_URL = "https://api.msg91.com/api/v5/otp/resend";
+    const OTP_RESEND_URL = "https://api.msg91.com/api/v5/otp/retry";
 
     /**
      * URL for send sms


### PR DESCRIPTION
OTP Resend URL was broken, according ti current API documentation it should be  **retry** and not **resend**.