### PR TITLE
fix(otp-resend): otp resend requires content type to be form data

### DIFF
--- a/src/OTP/ResendRequest.php
+++ b/src/OTP/ResendRequest.php
@@ -4,8 +4,11 @@ namespace Craftsys\Msg91\OTP;
 
 use Craftsys\Msg91\Support\Request;
 use Craftsys\Msg91\URLs;
+use GuzzleHttp\RequestOptions;
 
 class ResendRequest extends Request
 {
     protected $url = URLs::OTP_RESEND_URL;
+
+    protected $content_type = RequestOptions::FORM_PARAMS;
 }

--- a/tests/OTP/OTPServiceTest.php
+++ b/tests/OTP/OTPServiceTest.php
@@ -18,6 +18,8 @@ class OTPServiceTest extends TestCase
         "key" => "12345678901234567890"
     ];
 
+    protected $phone_number = 919999999999;
+
     protected $container = [];
 
     protected function setUp(): void
@@ -46,7 +48,7 @@ class OTPServiceTest extends TestCase
 
     public function test_otp_send()
     {
-        $phone_number = 919999999999;
+        $phone_number = $this->phone_number;
         $response = (new Client($this->config, $this->createMockHttpClient()))
             ->otp()
             ->from("SMSIND")
@@ -70,7 +72,7 @@ class OTPServiceTest extends TestCase
 
     public function test_verify_otp()
     {
-        $phone_number = 919999999999;
+        $phone_number = $this->phone_number;
         $otp = 1234;
         $response = (new Client($this->config, $this->createMockHttpClient()))
             ->otp($otp)
@@ -95,7 +97,7 @@ class OTPServiceTest extends TestCase
 
     public function test_otp_resend()
     {
-        $phone_number = 919999999999;
+        $phone_number = $this->phone_number;
         $response = (new Client($this->config, $this->createMockHttpClient()))
             ->otp()
             ->to($phone_number)
@@ -109,7 +111,7 @@ class OTPServiceTest extends TestCase
         // check the method
         $this->assertEquals("POST", $transaction['request']->getMethod());
         // check the request data
-        $data = (array) json_decode($transaction['request']->getBody()->getContents());
+        parse_str($transaction['request']->getBody()->getContents(), $data);
         $this->assertArrayHasKey('mobile', $data);
         $this->assertEquals($phone_number, $data['mobile']);
         $this->assertArrayHasKey('authkey', $data);
@@ -120,7 +122,7 @@ class OTPServiceTest extends TestCase
 
     public function test_api_key_required()
     {
-        $phone_number = 919999999999;
+        $phone_number = $this->phone_number;
         $this->expectException(ValidationException::class);
         (new Client([], $this->createMockHttpClient()))
             ->otp()


### PR DESCRIPTION
fixes #6 