### PR TITLE
fix(php8): required params should be first

### DIFF
--- a/src/Exceptions/ResponseErrorException.php
+++ b/src/Exceptions/ResponseErrorException.php
@@ -16,7 +16,7 @@ class ResponseErrorException extends Exception
      */
     protected $errors;
 
-    public function __construct($message = "", $code = 0, Throwable $previous = null, $errors)
+    public function __construct($message = "", $code = 0, Throwable $previous = null, $errors = null)
     {
         $this->errors = $errors;
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
For more details https://github.com/craftsys/msg91-laravel-notification-channel/issues/7, https://php.watch/versions/8.0/deprecate-required-param-after-optional