### PR TITLE
added support for digits in OTPService

### DIFF
--- a/src/OTP/OTPService.php
+++ b/src/OTP/OTPService.php
@@ -78,6 +78,16 @@ class OTPService extends Service
     }
 
     /**
+     * Set the otp length for OTPs
+     * @return $this
+     */
+    public function digits($otp_length = 4)
+    {
+        $this->options->digits($otp_length);
+        return $this;
+    }
+
+    /**
      * Send otp
      * @return \Craftsys\Msg91\Response
      */


### PR DESCRIPTION
Now digits can be set when sending OTPs

`Msg91::otp()->to($phone)->template($templateId)->digits(6)->send();`